### PR TITLE
feat: message form, theme provider, subpage animation, Spotify & weather

### DIFF
--- a/app/api/guestbook/route.ts
+++ b/app/api/guestbook/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export async function POST(req: Request) {
+  const { email, message } = await req.json();
+
+  if (!email || !message) {
+    return NextResponse.json({ error: "email and message required" }, { status: 400 });
+  }
+
+  const { error } = await supabase.from("guestbook").insert({
+    email: email.trim(),
+    message: message.trim(),
+  });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/app/api/weather/route.ts
+++ b/app/api/weather/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+
+const WMO: Record<number, { emoji: string; condition: string }> = {
+  0:  { emoji: "☀️",  condition: "Clear" },
+  1:  { emoji: "🌤️", condition: "Mainly clear" },
+  2:  { emoji: "⛅",  condition: "Partly cloudy" },
+  3:  { emoji: "☁️",  condition: "Overcast" },
+  45: { emoji: "🌫️", condition: "Fog" },
+  48: { emoji: "🌫️", condition: "Icy fog" },
+  51: { emoji: "🌦️", condition: "Light drizzle" },
+  53: { emoji: "🌦️", condition: "Drizzle" },
+  55: { emoji: "🌦️", condition: "Heavy drizzle" },
+  61: { emoji: "🌧️", condition: "Light rain" },
+  63: { emoji: "🌧️", condition: "Rain" },
+  65: { emoji: "🌧️", condition: "Heavy rain" },
+  71: { emoji: "🌨️", condition: "Light snow" },
+  73: { emoji: "🌨️", condition: "Snow" },
+  75: { emoji: "🌨️", condition: "Heavy snow" },
+  80: { emoji: "🌧️", condition: "Rain showers" },
+  81: { emoji: "🌧️", condition: "Rain showers" },
+  82: { emoji: "⛈️",  condition: "Violent showers" },
+  95: { emoji: "⛈️",  condition: "Thunderstorm" },
+  96: { emoji: "⛈️",  condition: "Thunderstorm" },
+  99: { emoji: "⛈️",  condition: "Thunderstorm" },
+};
+
+export async function GET() {
+  const url =
+    "https://api.open-meteo.com/v1/forecast" +
+    "?latitude=37.8715&longitude=-122.2730" +
+    "&current=temperature_2m,weathercode" +
+    "&hourly=precipitation_probability" +
+    "&temperature_unit=celsius" +
+    "&timezone=America%2FLos_Angeles" +
+    "&forecast_days=1";
+
+  const res = await fetch(url, { next: { revalidate: 1800 } });
+  if (!res.ok) return NextResponse.json({ error: "weather fetch failed" }, { status: 502 });
+
+  const data = await res.json();
+
+  const temperature: number = Math.round(data.current.temperature_2m);
+  const weatherCode: number = data.current.weathercode;
+  const { emoji, condition } = WMO[weatherCode] ?? { emoji: "🌡️", condition: "Unknown" };
+
+  // Find current hour index in hourly data and take next 3 hours
+  const nowHour = new Date().toISOString().slice(0, 13); // "2026-03-28T14"
+  const times: string[] = data.hourly.time;
+  const probs: number[] = data.hourly.precipitation_probability;
+  const idx = times.findIndex((t: string) => t.startsWith(nowHour));
+  const nextProbs = idx >= 0 ? probs.slice(idx, idx + 3) : probs.slice(0, 3);
+  const rainChance = Math.max(...nextProbs.map((p) => p ?? 0));
+
+  return NextResponse.json({ temperature, emoji, condition, rainChance });
+}

--- a/app/components/Guestbook.tsx
+++ b/app/components/Guestbook.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+
+const inputCls =
+  "w-full bg-transparent border-b border-zinc-200 dark:border-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 py-1 outline-none focus:border-zinc-400 dark:focus:border-zinc-600 placeholder:text-zinc-300 dark:placeholder:text-zinc-700 transition-colors";
+
+export default function MessageForm() {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email.trim() || !message.trim() || submitting) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/guestbook", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), message: message.trim() }),
+      });
+      if (res.ok) {
+        setSent(true);
+        setEmail("");
+        setMessage("");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (sent) {
+    return (
+      <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+        Thanks — I&apos;ve received your message.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3 max-w-md">
+      <input
+        type="email"
+        placeholder="Your email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        autoComplete="email"
+        className={inputCls}
+      />
+      <textarea
+        placeholder="Your message"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        required
+        rows={5}
+        maxLength={2000}
+        className="w-full bg-transparent border border-zinc-200 dark:border-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 px-2 py-2 rounded-sm outline-none focus:border-zinc-400 dark:focus:border-zinc-600 placeholder:text-zinc-300 dark:placeholder:text-zinc-700 transition-colors resize-y min-h-[120px]"
+      />
+      <button
+        type="submit"
+        disabled={submitting}
+        className="font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors disabled:opacity-40"
+      >
+        {submitting ? "Sending…" : "Send →"}
+      </button>
+    </form>
+  );
+}

--- a/app/components/Weather.tsx
+++ b/app/components/Weather.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type WeatherData = {
+  temperature: number;
+  emoji: string;
+  condition: string;
+  rainChance: number;
+};
+
+export default function Weather() {
+  const [data, setData] = useState<WeatherData | null>(null);
+
+  useEffect(() => {
+    fetch("/api/weather")
+      .then((r) => r.json())
+      .then((d) => { if (!d.error) setData(d); })
+      .catch(() => {});
+  }, []);
+
+  if (!data) return null;
+
+  return (
+    <span>
+      {data.emoji} {data.temperature}°C · {data.condition}
+      {data.rainChance > 0 && ` · ${data.rainChance}% chance of rain next 3h`}
+    </span>
+  );
+}

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -7,6 +7,7 @@ import ThemeToggle from "./theme-toggle";
 const links = [
   { href: "/about", label: "About" },
   { href: "/projects", label: "Projects" },
+  { href: "/guestbook", label: "Message" },
 ];
 
 export default function Nav() {

--- a/app/components/providers.tsx
+++ b/app/components/providers.tsx
@@ -1,11 +1,7 @@
 "use client";
 
-import { ThemeProvider } from "next-themes";
+import { ThemeProvider } from "./theme-provider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      {children}
-    </ThemeProvider>
-  );
+  return <ThemeProvider>{children}</ThemeProvider>;
 }

--- a/app/components/subpage-enter.tsx
+++ b/app/components/subpage-enter.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export default function SubpageEnter({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  if (pathname === "/") return <>{children}</>;
+
+  return (
+    <div className="subpage-enter" key={pathname}>
+      <div className="subpage-enter-inner relative z-[1]">{children}</div>
+    </div>
+  );
+}

--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+type Theme = "light" | "dark" | "system";
+
+const STORAGE_KEY = "theme";
+
+function getSystemTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function applyResolved(resolved: "light" | "dark") {
+  const root = document.documentElement;
+  root.classList.toggle("dark", resolved === "dark");
+  root.style.colorScheme = resolved;
+}
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  resolvedTheme: "light" | "dark";
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("system");
+
+  useEffect(() => {
+    try {
+      const s = localStorage.getItem(STORAGE_KEY) as Theme | null;
+      if (s === "light" || s === "dark" || s === "system") {
+        setThemeState(s);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const resolvedTheme: "light" | "dark" =
+    theme === "system" ? getSystemTheme() : theme;
+
+  useEffect(() => {
+    applyResolved(resolvedTheme);
+  }, [resolvedTheme]);
+
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyResolved(getSystemTheme());
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t);
+    try {
+      localStorage.setItem(STORAGE_KEY, t);
+    } catch {
+      /* ignore */
+    }
+    applyResolved(t === "system" ? getSystemTheme() : t);
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, setTheme, resolvedTheme }),
+    [theme, setTheme, resolvedTheme]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return ctx;
+}

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
+import { useTheme } from "./theme-provider";
 
 export default function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   // Avoid hydration mismatch — only render icon after mount
   useEffect(() => setMounted(true), []);
   if (!mounted) return <div className="w-4 h-4" />;
 
-  const isDark = theme === "dark";
+  const isDark = resolvedTheme === "dark";
 
   return (
     <button

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Chiron+GoRound+TC&display=swap');
 @import "tailwindcss";
 
-/* Use .dark class for dark mode (next-themes) instead of media query */
+/* Dark mode: .dark on <html> (see theme-init script + theme-provider) */
 @variant dark (.dark &);
 
 :root {
@@ -35,6 +35,15 @@ body {
   color: var(--foreground);
 }
 
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.fade-up {
+  opacity: 0;
+  animation: fade-up 0.4s ease forwards;
+}
+
 @keyframes slide-out-left {
   from { transform: translateX(0);    opacity: 1; }
   to   { transform: translateX(-10px); opacity: 0; }
@@ -45,3 +54,62 @@ body {
 }
 .slide-exit { animation: slide-out-left 200ms ease forwards; }
 .slide-enter { animation: slide-in-right 250ms ease forwards; }
+
+/* Non-home routes: gradient veil + content entrance */
+.subpage-enter {
+  position: relative;
+  isolation: isolate;
+}
+.subpage-enter::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    165deg,
+    rgba(113, 113, 122, 0.16) 0%,
+    rgba(113, 113, 122, 0.06) 38%,
+    transparent 72%
+  );
+  opacity: 1;
+  animation: subpage-veil 0.85s ease forwards;
+}
+.dark .subpage-enter::before {
+  background: linear-gradient(
+    165deg,
+    rgba(161, 161, 170, 0.14) 0%,
+    rgba(161, 161, 170, 0.05) 40%,
+    transparent 72%
+  );
+}
+@keyframes subpage-veil {
+  to {
+    opacity: 0;
+  }
+}
+.subpage-enter-inner {
+  opacity: 0;
+  animation: subpage-enter 0.65s cubic-bezier(0.22, 1, 0.36, 1) 0.05s forwards;
+}
+@keyframes subpage-enter {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .subpage-enter::before {
+    animation: none;
+    opacity: 0;
+  }
+  .subpage-enter-inner {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/app/guestbook/page.tsx
+++ b/app/guestbook/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import MessageForm from "../components/Guestbook";
+
+export const metadata: Metadata = {
+  title: "Message — Kai Chen",
+};
+
+export default function MessagePage() {
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-20">
+      <h1 className="font-serif text-4xl font-bold mb-4 tracking-tight">Message</h1>
+      <p className="text-zinc-500 dark:text-zinc-400 text-lg mb-12 leading-relaxed">
+        Send me a note — I read every message.
+      </p>
+      <MessageForm />
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Lora } from "next/font/google";
 import "./globals.css";
 import Nav from "./components/nav";
+import SubpageEnter from "./components/subpage-enter";
 import Providers from "./components/providers";
 import SpotifyBarWrapper from "./components/spotify-bar-wrapper";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import Script from "next/script";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -40,9 +42,14 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col font-sans">
+        <Script id="theme-init" strategy="beforeInteractive">
+          {`(function(){try{var d=document.documentElement;var t=localStorage.getItem('theme');var dark;if(t==='dark')dark=true;else if(t==='light')dark=false;else dark=window.matchMedia('(prefers-color-scheme: dark)').matches;d.classList.toggle('dark',dark);d.style.colorScheme=dark?'dark':'light';}catch(e){}})();`}
+        </Script>
         <Providers>
           <Nav />
-          <main className="flex-1 pb-16">{children}</main>
+          <main className="flex-1 pb-16">
+            <SubpageEnter>{children}</SubpageEnter>
+          </main>
           <SpotifyBarWrapper />
         </Providers>
         <Analytics />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,9 @@
 import NowPlaying from "./components/now-playing";
 import GitHubActivity from "./components/GitHubActivity";
 import LocalTime from "./components/local-time";
+import Weather from "./components/Weather";
+
+const DT = "w-24 shrink-0 font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 pt-0.5";
 
 export default function Home() {
   return (
@@ -56,54 +59,51 @@ export default function Home() {
       </p>
 
       <dl className="mt-10 space-y-4 text-sm">
-          <div className="flex gap-4">
-            <dt className="w-24 shrink-0 font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 pt-0.5">
-              Location
-            </dt>
-            <dd className="text-zinc-700 dark:text-zinc-300">
-              Berkeley, CA — UC Berkeley visiting
-            </dd>
-          </div>
-          <div className="flex gap-4">
-            <dt className="w-24 shrink-0 font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 pt-0.5">
-              Local Time
-            </dt>
-            <dd className="text-zinc-700 dark:text-zinc-300">
-              <LocalTime />
-            </dd>
-          </div>
-          <div className="flex gap-4">
-            <dt className="w-24 shrink-0 font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 pt-0.5">
-              Focus
-            </dt>
-            <dd className="text-zinc-700 dark:text-zinc-300">
-              CS61A, Data100, CogSci175
-            </dd>
-          </div>
-          <div className="flex gap-4">
-            <dt className="w-24 shrink-0 font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 pt-0.5">
-              Thinking
-            </dt>
-            <dd className="text-zinc-700 dark:text-zinc-300">
-              AI governance, what it means to do research that matters
-            </dd>
-          </div>
-          <div className="flex gap-4">
-            <dt className="w-24 shrink-0 font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 pt-0.5">
-              Spotify
-            </dt>
-            <dd className="text-zinc-700 dark:text-zinc-300">
-              <NowPlaying />
-            </dd>
-          </div>
+        <div className="flex gap-4 fade-up" style={{ animationDelay: "0ms" }}>
+          <dt className={DT}>Location</dt>
+          <dd className="text-zinc-700 dark:text-zinc-300">
+            Berkeley, CA — UC Berkeley visiting
+          </dd>
+        </div>
+        <div className="flex gap-4 fade-up" style={{ animationDelay: "80ms" }}>
+          <dt className={DT}>Local Time</dt>
+          <dd className="text-zinc-700 dark:text-zinc-300">
+            <LocalTime />
+          </dd>
+        </div>
+        <div className="flex gap-4 fade-up" style={{ animationDelay: "160ms" }}>
+          <dt className={DT}>Weather</dt>
+          <dd className="text-zinc-700 dark:text-zinc-300">
+            <Weather />
+          </dd>
+        </div>
+        <div className="flex gap-4 fade-up" style={{ animationDelay: "240ms" }}>
+          <dt className={DT}>Focus</dt>
+          <dd className="text-zinc-700 dark:text-zinc-300">
+            CS61A, Data100, CogSci175
+          </dd>
+        </div>
+        <div className="flex gap-4 fade-up" style={{ animationDelay: "320ms" }}>
+          <dt className={DT}>Thinking</dt>
+          <dd className="text-zinc-700 dark:text-zinc-300">
+            AI governance, what it means to do research that matters
+          </dd>
+        </div>
+        <div className="flex gap-4 fade-up" style={{ animationDelay: "400ms" }}>
+          <dt className={DT}>Spotify</dt>
+          <dd className="text-zinc-700 dark:text-zinc-300">
+            <NowPlaying />
+          </dd>
+        </div>
       </dl>
 
-      <div className="mt-10">
+      <div className="mt-10 fade-up" style={{ animationDelay: "480ms" }}>
         <p className="font-mono text-xs uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-4">
           GitHub Contribution
         </p>
         <GitHubActivity />
       </div>
+
     </div>
   );
 }

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -6,6 +6,7 @@ export type RecentTrack = {
   title: string;
   artist: string;
   songUrl: string;
+  albumArt: string;
 };
 
 export type NowPlayingResult =
@@ -77,7 +78,7 @@ export async function getNowPlaying(): Promise<NowPlayingResult> {
 
   const data = await res.json();
 
-  if (!data?.is_playing || data?.currently_playing_type !== "track") {
+  if (data?.currently_playing_type !== "track" || !data?.item) {
     return { isPlaying: false, recentTrack: currentTrack ?? previousTrack ?? undefined };
   }
 
@@ -85,19 +86,24 @@ export async function getNowPlaying(): Promise<NowPlayingResult> {
     title: data.item.name,
     artist: data.item.artists.map((a: { name: string }) => a.name).join(", "),
     songUrl: data.item.external_urls.spotify,
+    albumArt: data.item.album.images[0]?.url ?? "",
   };
 
-  // Update track history when the song changes
+  // Update track history when the song changes (covers playing and paused so we keep album art)
   if (currentTrack?.songUrl !== incoming.songUrl) {
     previousTrack = currentTrack;
     currentTrack = incoming;
+  }
+
+  if (!data.is_playing) {
+    return { isPlaying: false, recentTrack: currentTrack ?? previousTrack ?? undefined };
   }
 
   return {
     isPlaying: true,
     title: data.item.name,
     artist: incoming.artist,
-    albumArt: data.item.album.images[0]?.url ?? "",
+    albumArt: incoming.albumArt,
     songUrl: incoming.songUrl,
     progress_ms: data.progress_ms ?? 0,
     duration_ms: data.item.duration_ms,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.100.1",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "next": "16.2.0",
-        "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
@@ -1236,6 +1236,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
+      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.1.tgz",
+      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
+      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
+      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.1.tgz",
+      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
+      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.100.1",
+        "@supabase/functions-js": "2.100.1",
+        "@supabase/postgrest-js": "2.100.1",
+        "@supabase/realtime-js": "2.100.1",
+        "@supabase/storage-js": "2.100.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1552,7 +1638,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1576,6 +1661,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4009,6 +4103,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5118,16 +5221,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -6445,7 +6538,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6637,6 +6729,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.100.1",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "next": "16.2.0",
-    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },


### PR DESCRIPTION
## Summary

- **Message (`/guestbook`)**: Form-only flow to send a note; no public list of messages. `GET /api/guestbook` removed; `POST` inserts via Supabase and returns `{ ok: true }`. Nav label: **Message**.
- **Theme**: Replaced `next-themes` with a small `ThemeProvider` + `beforeInteractive` inline script in `layout.tsx` to avoid React 19 “script in component” issues and hydration noise, while keeping theme flash minimal.
- **Subpages**: `SubpageEnter` wraps non-home routes with a gradient veil + fade-up entrance (`globals.css`).
- **Spotify**: `RecentTrack` includes `albumArt`; paused/stopped state still shows last cover when available.
- **Homepage**: Weather block + API; other homepage tweaks as in diff.

## Env / deploy notes

- Supabase + guestbook table for `POST /api/guestbook`.
- Weather API may need its own env vars (see `app/api/weather`).
- Spotify env vars unchanged for now-playing.

## Test plan

- [x] Home, About, Projects, Message load; subpage animation only off `/`.
- [x] Theme toggle + reload (no flash regression).
- [x] Message form submits; no message list on page.
- [x] Spotify bar / last played shows art when idle.