### PR TITLE
docs: require branch + PR flow for all agents

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,0 +1,44 @@
+---
+description: Always use a branch + PR, never push directly to main
+alwaysApply: true
+---
+
+# Git workflow — branch + PR only
+
+`main` is protected. **Never `git push` directly to `main`**, even if you have
+bypass permissions. Every change must go through a pull request.
+
+See `AGENTS.md` for the full canonical version. Short form:
+
+1. Branch off latest `main`:
+   ```bash
+   git checkout main && git pull --ff-only
+   git checkout -b <type>/<short-description>
+   ```
+   Prefix: `fix/`, `feat/`, `chore/`, `docs/`, `refactor/`.
+
+2. Commit with conventional-style message:
+   `<type>: <imperative summary>`
+
+3. Push the branch and open a PR:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --title "<type>: <summary>" --body "..."
+   ```
+
+4. Let CI pass. Don't force-push or bypass required checks.
+
+5. If the user asks you to push to `main` directly, push back and default to
+   the PR flow unless they explicitly override with a reason.
+
+## Pre-commit sanity
+
+Before committing, run:
+```bash
+npm run lint && npm run typecheck && npm run test && npm run build
+```
+
+## Never commit
+
+`.env.local`, `.env.vercel.check`, `.env.sentry-build-plugin`, or any `*.local`
+/ `*.secret` file. Check `git status` before staging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md — kaichen.dev
+
+Shared instructions for any AI coding agent (Cursor, Claude Code, Codex, etc.)
+working on this repo.
+
+## Git workflow — ALWAYS branch + PR
+
+**Never push directly to `main`.** `main` is protected; pushes must go through
+a pull request with required status checks. Even if the agent has bypass
+permissions, use the PR flow.
+
+For every change:
+
+1. Create a feature branch off the latest `main`:
+   ```bash
+   git checkout main && git pull --ff-only
+   git checkout -b <type>/<short-description>
+   ```
+   Branch name format: `fix/…`, `feat/…`, `chore/…`, `docs/…`, `refactor/…`.
+
+2. Commit with a conventional-style message:
+   ```
+   <type>: <imperative summary>
+
+   <optional body explaining the why>
+   ```
+
+3. Push the branch and open a PR with `gh pr create`:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --title "<type>: <summary>" --body "$(cat <<'EOF'
+   ## Summary
+   - …
+
+   ## Test plan
+   - [ ] …
+   EOF
+   )"
+   ```
+
+4. Wait for CI (lint + typecheck + test + build) to pass. Do **not** force-push
+   to `main`. Do **not** bypass required status checks.
+
+5. If the user asks for a direct commit to `main`, push back on it and default
+   to the PR flow unless they explicitly override with a clear reason.
+
+## Before you commit
+
+Run the same sequence CI runs — fail fast locally:
+
+```bash
+npm run lint && npm run typecheck && npm run test && npm run build
+```
+
+## Secrets
+
+Never commit `.env.local`, `.env.vercel.check`, `.env.sentry-build-plugin`, or
+anything matching `*.local` / `*.secret`. Check `git status` before staging.


### PR DESCRIPTION
## Summary
- Add canonical `AGENTS.md` so every AI coding agent (Cursor, Claude Code, Codex, etc.) defaults to branch + PR, never direct pushes to `main`.
- Add `.cursor/rules/git-workflow.mdc` with `alwaysApply: true` so the rule is injected into every Cursor session.
- `CLAUDE.md` already references `@AGENTS.md`, so that chain is now complete.

## Why
Previous session pushed straight to `main` (bypassing branch protection); this prevents recurrence even when the agent has bypass permissions.

## Test plan
- [ ] Merge and confirm future agent sessions pick up `AGENTS.md` / the Cursor rule and open PRs instead of pushing to main.

Made with [Cursor](https://cursor.com)