### PR TITLE
chore(ci): group dependabot updates, scope auto-merge to dependabot patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,75 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: scope
+    groups:
+      fontsource:
+        patterns:
+          - "@fontsource/*"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      supabase:
+        patterns:
+          - "@supabase/*"
+      mdx:
+        patterns:
+          - "@mdx-js/*"
+          - "@next/mdx"
+          - "remark-*"
+          - "rehype-*"
+      vercel:
+        patterns:
+          - "@vercel/*"
+      types:
+        patterns:
+          - "@types/*"
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    # Major upgrades for framework/runtime are tracked manually — they usually
+    # ship codemods or breaking changes we want to review deliberately.
+    ignore:
+      - dependency-name: next
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-dom
+        update-types: ["version-update:semver-major"]
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      - dependency-name: eslint-config-next
+        update-types: ["version-update:semver-major"]
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+      - dependency-name: tailwindcss
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@tailwindcss/postcss"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,38 +1,27 @@
-name: Auto Merge after Vercel Deployment
+name: Auto-merge Dependabot minor/patch
 
-on:
-  check_run:
-    types: [completed]
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  auto-merge:
-    if: |
-      github.event.check_run.name == 'Vercel' &&
-      github.event.check_run.conclusion == 'success'
+  dependabot:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Find associated PR
-        id: find-pr
-        uses: actions/github-script@v7
+      - name: Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
         with:
-          script: |
-            const prs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:${github.event.check_run.check_suite.head_branch}`
-            });
-            if (prs.data.length > 0) {
-              return prs.data[0].number;
-            }
-            return null;
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge
-        if: steps.find-pr.outputs.result != 'null'
-        run: gh pr merge --auto --squash "#${{ steps.find-pr.outputs.result }}"
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Tame Dependabot PR noise and make auto-merge safe.

### `dependabot.yml`
- **Group npm updates by family** (`sentry`, `supabase`, `mdx`, `fontsource`, `vercel`, `types`), plus a catch-all `minor-and-patch` group. Weekly runs will now open ~1-2 PRs instead of 10+.
- Schedule pinned to Monday 09:00 America/Los_Angeles for both npm and github-actions, both labelled `dependencies`.
- Conventional-style commit prefixes: `chore(deps)` / `chore(deps-dev)` / `chore(ci)`.
- **Ignore major bumps** for \`next\`, \`react\`, \`react-dom\`, \`typescript\`, \`eslint\`, \`eslint-config-next\`, \`tailwindcss\`, \`@tailwindcss/postcss\`. Framework majors get reviewed manually — they usually ship codemods / breaking changes.

### `auto-merge.yml`
- Rewritten around the official \`dependabot/fetch-metadata@v2\` action.
- Triggers **only on \`dependabot[bot]\` PRs**. Human PRs no longer auto-merge (previously, any PR with a passing Vercel check got squash-merged).
- Auto-merge is enabled **only for \`version-update:semver-patch\` and \`:semver-minor\`**. Major upgrades (should any slip past the ignore list) require manual merge.
- Branch protection's required checks (lint + typecheck + test + build) still gate the actual merge — \`gh pr merge --auto\` just queues it.

## Why
There are 8 existing Dependabot PRs sitting open; the old auto-merge would happily flip them green on Vercel and ship. This PR consolidates them into grouped weekly PRs and scopes the auto-merge so only non-risky updates go through without a human glance.

## Test plan
- [ ] Merge this PR.
- [ ] Close / recreate the existing 8 Dependabot PRs (or let them run next Monday when they'll be re-grouped).
- [ ] Verify next Monday's run produces grouped PRs with \`chore(deps):\` prefix and \`dependencies\` label.
- [ ] Verify a human PR no longer gets auto-merged on Vercel success.

Made with [Cursor](https://cursor.com)