### PR TITLE
chore: auto-credit Claude as co-author on every commit

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -20,6 +20,13 @@ See `AGENTS.md` for the full canonical version. Short form:
 2. Commit with conventional-style message:
    `<type>: <imperative summary>`
 
+   **Every commit must credit Claude as co-author.** `.githooks/prepare-commit-msg`
+   appends the trailer automatically after `npm install`, but include it
+   explicitly anyway as defense-in-depth:
+   ```
+   Co-authored-by: Claude <noreply@anthropic.com>
+   ```
+
 3. Push the branch and open a PR:
    ```bash
    git push -u origin HEAD

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Appends a Co-authored-by trailer crediting Claude on every commit.
+#
+# Activated via `core.hooksPath = .githooks`, which is set automatically by the
+# `postinstall` npm script. To install manually, run:
+#   git config core.hooksPath .githooks
+
+set -e
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Skip for true merge commits (they carry their own author metadata) but run
+# for everything else including squash, amend, and template-based commits.
+case "$COMMIT_SOURCE" in
+  merge) exit 0 ;;
+esac
+
+COAUTHOR="Co-authored-by: Claude <noreply@anthropic.com>"
+
+# `git interpret-trailers` handles trailer placement (blank line before,
+# existing trailers, duplicates) correctly.
+git interpret-trailers \
+  --in-place \
+  --if-exists addIfDifferent \
+  --trailer "$COAUTHOR" \
+  "$COMMIT_MSG_FILE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,17 @@ For every change:
    ```
    Branch name format: `fix/…`, `feat/…`, `chore/…`, `docs/…`, `refactor/…`.
 
-2. Commit with a conventional-style message:
+2. Commit with a conventional-style message. **Every commit in this repo must
+   credit Claude as a co-author** — `.githooks/prepare-commit-msg` appends the
+   trailer automatically once `npm install` has run, but include it explicitly
+   anyway (e.g. when you commit via an API/web editor that skips git hooks):
+
    ```
    <type>: <imperative summary>
 
    <optional body explaining the why>
+
+   Co-authored-by: Claude <noreply@anthropic.com>
    ```
 
 3. Push the branch and open a PR with `gh pr create`:
@@ -51,6 +57,18 @@ Run the same sequence CI runs — fail fast locally:
 ```bash
 npm run lint && npm run typecheck && npm run test && npm run build
 ```
+
+## Git hooks (co-author trailer)
+
+This repo ships a `prepare-commit-msg` hook at `.githooks/prepare-commit-msg`
+that appends `Co-authored-by: Claude <noreply@anthropic.com>` on every commit
+(skipped for merge commits). `npm install` sets `core.hooksPath = .githooks`
+via the `postinstall` script, so the hook activates automatically after a
+fresh clone + install.
+
+If you commit in an environment where the hook can't run (GitHub web editor,
+some sandboxed agents, `-n` / `--no-verify` situations), add the trailer
+manually so the policy is never silently dropped.
 
 ## Secrets
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "postinstall": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
     "@fontsource/bitter": "^5.2.10",


### PR DESCRIPTION
## Summary
- Adds `.githooks/prepare-commit-msg` that appends `Co-authored-by: Claude <noreply@anthropic.com>` via `git interpret-trailers` (idempotent, skips merge commits).
- `package.json` `postinstall` runs `git config core.hooksPath .githooks`, so any fresh clone picks up the hook after `npm install` — no husky dependency.
- `AGENTS.md` + `.cursor/rules/git-workflow.mdc` document the policy so agents also add the trailer explicitly when committing in environments where git hooks are skipped (web editor, sandboxed runs, `--no-verify`).

## Test plan
- [x] Verified this very commit picked up the trailer (`git log -1` shows `Co-authored-by: Claude`).
- [x] `npm run lint && npm run typecheck && npm run test` pass locally.
- [ ] CI green on this PR.

Made with [Cursor](https://cursor.com)