### PR TITLE
feat: clipboard sync at /clip with supabase auth + realtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,21 @@
 # =============================================================================
 
 # --- Supabase ----------------------------------------------------------------
-# Only used by /api/lastfm/now-playing for optional listening history.
-# NEXT_PUBLIC_SUPABASE_URL is paired with the service role key for server-side
-# reads/writes against `listening_history` / `listening_stats`.
+# Powers /api/lastfm/now-playing (optional listening history) and the Clipboard
+# Sync feature at /clip (auth + RLS-backed rooms + realtime).
 NEXT_PUBLIC_SUPABASE_URL=
+
+# Public anon key — used by browser + server clients with cookie-based auth.
+# Required for /clip; optional for the Last.fm route (which uses service role).
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
 # Server-only: bypasses Row Level Security — NEVER expose to the client.
 SUPABASE_SERVICE_ROLE_KEY=
+
+# --- Clipboard Sync ----------------------------------------------------------
+# Comma-separated list of admin emails for /clip/admin. Compared against the
+# signed-in Supabase session email (case-insensitive).
+ADMIN_EMAILS=
 
 # --- Last.fm -----------------------------------------------------------------
 # API key from https://www.last.fm/api/account/create

--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ The site combines:
 - **MDX-powered notes** under `/notes` with math (KaTeX), GitHub-flavored Markdown, and syntax-highlighted code blocks — multiple course segments (UC Berkeley and SUSTech); see [MDX lecture notes](#mdx-lecture-notes).
 - **Optional observability** via Sentry (client, server, edge) and Vercel Analytics / Speed Insights.
 
-There is **no** `middleware.ts` (or `proxy.ts`) in this repo — every route is publicly accessible and rendered by the App Router directly.
+A single `proxy.ts` (the Next.js 16 successor to `middleware.ts`) lives at the repo root. It does two things:
+
+1. Refreshes the Supabase auth cookie on every request (required for `/clip` server components).
+2. Rewrites the `clip.kaichen.dev` subdomain into the `/clip/*` path tree so one project serves both `kaichen.dev/clip` and `clip.kaichen.dev`.
+
+Public marketing routes are unaffected.
 
 ---
 
@@ -224,6 +229,11 @@ Pinned versions are in [`package.json`](package.json).
 | `/notes` | Index of courses (see [MDX lecture notes](#mdx-lecture-notes)); links to external [SUSTech-Kai-Notes](https://github.com/kaiiiichen/SUSTech-Kai-Notes) for broader collections |
 | `/notes/...` | Nested segments per course (e.g. `cs61a`, `data100`, `cs217`, `ma121`–`ma337`); individual notes are `page.mdx` |
 | `/berkeley-libraries` | UC Berkeley library **open/closed** status and hours, parsed from [lib.berkeley.edu/hours](https://www.lib.berkeley.edu/hours); data revalidates every **15 minutes** |
+| `/clip` | **Clipboard Sync** — Google sign-in (Supabase Auth), lists rooms the user belongs to. Also reachable as the root of `clip.kaichen.dev` via middleware rewrite. |
+| `/clip/board/[id]` | Single clipboard room: history list on the left, editor + selected entry on the right. Live-syncs new entries via Supabase Realtime (`postgres_changes` on `clipboard_entries`). |
+| `/clip/admin` | Admin panel (only emails in `ADMIN_EMAILS`): list signed-up users, create/delete rooms, add/remove members with `read` / `write` roles. |
+| `GET /auth/callback` | Supabase OAuth code exchange — set `https://clip.kaichen.dev/auth/callback` (and `https://kaichen.dev/auth/callback`) as redirect URLs in Supabase Auth. |
+| `POST /auth/sign-out` | Server-side sign-out for Clipboard Sync. |
 
 **External nav (no in-app route):** the main nav includes **News** → [news.kaichen.dev](https://news.kaichen.dev) and **Blog** → [Substack](https://kaiiiichen.substack.com/); there is no `/blog` or `/news` route in this repo.
 
@@ -255,8 +265,10 @@ Copy [`.env.example`](.env.example) to `.env.local`. **Never commit** real secre
 
 | Variable | Role |
 | --- | --- |
-| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL. Paired with `SUPABASE_SERVICE_ROLE_KEY` inside `/api/lastfm/now-playing` for the optional listening history. |
-| `SUPABASE_SERVICE_ROLE_KEY` | **Server-only.** Used by `/api/lastfm/now-playing` for DB writes/reads against `listening_history` / `listening_stats` — keep off the client bundle. |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL. Used by `/api/lastfm/now-playing` (service-role writes) and Clipboard Sync (`/clip`). |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public anon key for cookie-based auth + RLS-scoped reads/writes from `/clip`. Required for Clipboard Sync; safe to expose. |
+| `SUPABASE_SERVICE_ROLE_KEY` | **Server-only.** Used by `/api/lastfm/now-playing` and the `/clip/admin` panel (creating rooms, listing users, managing members). Keep off the client bundle. |
+| `ADMIN_EMAILS` | Comma-separated emails allowed to use `/clip/admin` (case-insensitive). Compared against the signed-in Supabase session email. |
 | `LASTFM_API_KEY` | Last.fm API. If unset, the now-playing API returns a graceful “not playing” / DB fallback without calling Last.fm. |
 | `GITHUB_TOKEN` | Fine-grained or classic PAT for GitHub API (contributions + stars + **pinned repos** on the home page). If missing, contribution/stars features may error or return empty data; pinned projects fall back to a **static list** in [`app/lib/github-pinned.ts`](app/lib/github-pinned.ts). |
 | `GITHUB_LOGIN` | Optional. GitHub username for **pinned repositories** and related API calls (defaults to `kaiiiichen` if unset). Set when forking so the home page shows your pins. |
@@ -278,7 +290,7 @@ That path is gitignored — do not commit it.
 
 ### CI
 
-CI does not need any real Supabase keys to build — every Supabase client in this repo is constructed lazily inside a function body, so `next build` succeeds without `NEXT_PUBLIC_SUPABASE_*` set. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+CI does not need any real Supabase keys to build — every Supabase client in this repo is constructed lazily inside a function body, so `next build` succeeds without `NEXT_PUBLIC_SUPABASE_*` set. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml). The `/clip` routes are `force-dynamic`, so they aren't statically pre-rendered at build time either.
 
 ---
 
@@ -308,6 +320,8 @@ To add a new course: add a card on the notes index, create `app/notes/<slug>/pag
 | **Supabase** | Optional `listening_history` / `listening_stats` writes (service role) for the now-playing route |
 | **Substack RSS** | Home page “latest posts” (`app/lib/substack.ts`) |
 | **lib.berkeley.edu** | Library hours HTML (scraped server-side; not an official API) |
+| **Supabase Auth (Google)** | Sign-in for `/clip` Clipboard Sync (cookie-based session via `@supabase/ssr`) |
+| **Supabase Realtime** | `clipboard_entries` `INSERT` events broadcast to room subscribers in `/clip/board/[id]` |
 
 ---
 
@@ -386,8 +400,16 @@ to non-merge commits via `git interpret-trailers` (idempotent). Automation that 
 ## Deployment
 
 1. Connect the GitHub repository to **Vercel**.
-2. Set environment variables in the Vercel project (production + preview as needed), especially `GITHUB_TOKEN`, `LASTFM_API_KEY`, and the Supabase keys if you want listening history persistence.
+2. Set environment variables in the Vercel project (production + preview as needed), especially `GITHUB_TOKEN`, `LASTFM_API_KEY`, the Supabase keys (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`), and `ADMIN_EMAILS` for Clipboard Sync.
 3. Pushes to `main` typically deploy production; preview deployments use PR branches.
+
+### Clipboard Sync (`clip.kaichen.dev`)
+
+Once the env vars above are set:
+
+1. **Vercel:** add `clip.kaichen.dev` as a domain on the same project. The middleware rewrites `clip.kaichen.dev` → `/clip` so no extra routing is needed.
+2. **Supabase Auth → URL configuration:** add both `https://kaichen.dev/auth/callback` and `https://clip.kaichen.dev/auth/callback` (plus `http://localhost:3000/auth/callback` for dev) to the redirect URL allowlist; enable the **Google** provider.
+3. **Supabase tables:** the schema (`clipboards`, `clipboard_members`, `clipboard_entries`) is created manually — see the project brief / migrations. Enable **Realtime** on `clipboard_entries` and configure RLS so users can only see rooms they belong to (the app relies on RLS for `SELECT`/`INSERT` from the browser).
 
 Manual CLI (after `vercel link`):
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getServerSupabase } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = request.nextUrl;
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/clip";
+
+  if (code) {
+    const supabase = await getServerSupabase();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/clip?error=auth_failed`);
+}

--- a/app/auth/sign-out/route.ts
+++ b/app/auth/sign-out/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getServerSupabase } from "@/lib/supabase/server";
+
+export async function POST(request: NextRequest) {
+  const supabase = await getServerSupabase();
+  await supabase.auth.signOut();
+  return NextResponse.redirect(new URL("/clip", request.url), { status: 303 });
+}

--- a/app/clip/actions.ts
+++ b/app/clip/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getServerSupabase } from "@/lib/supabase/server";
+
+export async function postClipboardEntry(formData: FormData): Promise<{ ok: true } | { ok: false; error: string }> {
+  const clipboardId = String(formData.get("clipboard_id") ?? "").trim();
+  const content = String(formData.get("content") ?? "");
+
+  if (!clipboardId) return { ok: false, error: "Missing clipboard id." };
+  if (!content.trim()) return { ok: false, error: "Content cannot be empty." };
+
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  // RLS enforces that user must have role='write' on this clipboard.
+  const { error } = await supabase.from("clipboard_entries").insert({
+    clipboard_id: clipboardId,
+    user_id: user.id,
+    content,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath(`/clip/board/${clipboardId}`);
+  return { ok: true };
+}

--- a/app/clip/admin/admin-actions.ts
+++ b/app/clip/admin/admin-actions.ts
@@ -1,0 +1,107 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getServerSupabase } from "@/lib/supabase/server";
+import { getAdminSupabase } from "@/lib/supabase/admin";
+import { isAdminEmail } from "@/lib/clip/admin";
+import type { ClipboardRole } from "@/lib/clip/types";
+
+type ActionResult = { ok: true } | { ok: false; error: string };
+
+async function requireAdmin(): Promise<{ id: string; email: string } | { error: string }> {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not signed in." };
+  if (!isAdminEmail(user.email)) return { error: "Forbidden." };
+  return { id: user.id, email: user.email ?? "" };
+}
+
+export async function createClipboardAction(formData: FormData): Promise<ActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return { ok: false, error: auth.error };
+
+  const name = String(formData.get("name") ?? "").trim();
+  if (!name) return { ok: false, error: "Name is required." };
+
+  const admin = getAdminSupabase();
+  const { data, error } = await admin
+    .from("clipboards")
+    .insert({ name, created_by: auth.id })
+    .select("id")
+    .single();
+  if (error || !data) return { ok: false, error: error?.message ?? "Failed to create." };
+
+  // Creator gets write access by default.
+  await admin.from("clipboard_members").insert({
+    clipboard_id: data.id,
+    user_id: auth.id,
+    role: "write",
+  });
+
+  revalidatePath("/clip/admin");
+  revalidatePath("/clip");
+  return { ok: true };
+}
+
+export async function deleteClipboardAction(formData: FormData): Promise<ActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return { ok: false, error: auth.error };
+
+  const clipboardId = String(formData.get("clipboard_id") ?? "");
+  if (!clipboardId) return { ok: false, error: "Missing clipboard id." };
+
+  const admin = getAdminSupabase();
+  const { error } = await admin.from("clipboards").delete().eq("id", clipboardId);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/clip/admin");
+  revalidatePath("/clip");
+  return { ok: true };
+}
+
+export async function addMemberAction(formData: FormData): Promise<ActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return { ok: false, error: auth.error };
+
+  const clipboardId = String(formData.get("clipboard_id") ?? "");
+  const userId = String(formData.get("user_id") ?? "");
+  const roleRaw = String(formData.get("role") ?? "read");
+  const role: ClipboardRole = roleRaw === "write" ? "write" : "read";
+
+  if (!clipboardId || !userId) return { ok: false, error: "Missing clipboard or user id." };
+
+  const admin = getAdminSupabase();
+  const { error } = await admin.from("clipboard_members").upsert(
+    { clipboard_id: clipboardId, user_id: userId, role },
+    { onConflict: "clipboard_id,user_id" }
+  );
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/clip/admin");
+  revalidatePath("/clip");
+  revalidatePath(`/clip/board/${clipboardId}`);
+  return { ok: true };
+}
+
+export async function removeMemberAction(formData: FormData): Promise<ActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return { ok: false, error: auth.error };
+
+  const clipboardId = String(formData.get("clipboard_id") ?? "");
+  const userId = String(formData.get("user_id") ?? "");
+  if (!clipboardId || !userId) return { ok: false, error: "Missing clipboard or user id." };
+
+  const admin = getAdminSupabase();
+  const { error } = await admin
+    .from("clipboard_members")
+    .delete()
+    .eq("clipboard_id", clipboardId)
+    .eq("user_id", userId);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/clip/admin");
+  revalidatePath(`/clip/board/${clipboardId}`);
+  return { ok: true };
+}

--- a/app/clip/admin/admin-panel.tsx
+++ b/app/clip/admin/admin-panel.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useTransition, useMemo } from "react";
+import {
+  addMemberAction,
+  createClipboardAction,
+  deleteClipboardAction,
+  removeMemberAction,
+} from "./admin-actions";
+
+export interface AdminUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+  avatar_url: string | null;
+  created_at: string;
+}
+
+export interface AdminClipboard {
+  id: string;
+  name: string;
+  created_at: string;
+  created_by: string | null;
+  members: { user_id: string; role: "read" | "write"; created_at: string }[];
+  entry_count: number;
+}
+
+interface Props {
+  users: AdminUser[];
+  clipboards: AdminClipboard[];
+}
+
+export default function AdminPanel({ users, clipboards }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(clipboards[0]?.id ?? null);
+  const [feedback, setFeedback] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const selected = useMemo(
+    () => clipboards.find((c) => c.id === selectedId) ?? clipboards[0] ?? null,
+    [clipboards, selectedId]
+  );
+
+  const usersById = useMemo(() => {
+    const m = new Map<string, AdminUser>();
+    for (const u of users) m.set(u.id, u);
+    return m;
+  }, [users]);
+
+  const memberIds = useMemo(
+    () => new Set(selected?.members.map((m) => m.user_id) ?? []),
+    [selected]
+  );
+
+  const nonMembers = useMemo(
+    () => users.filter((u) => !memberIds.has(u.id)),
+    [users, memberIds]
+  );
+
+  function runAction(
+    action: (formData: FormData) => Promise<{ ok: true } | { ok: false; error: string }>,
+    formData: FormData,
+    onSuccess?: () => void
+  ) {
+    startTransition(async () => {
+      const result = await action(formData);
+      if (result.ok) {
+        setFeedback({ kind: "ok", msg: "Saved." });
+        onSuccess?.();
+      } else {
+        setFeedback({ kind: "err", msg: result.error });
+      }
+    });
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-4 fade-up" style={{ animationDelay: "60ms" }}>
+      {/* Left — clipboards list + create */}
+      <aside className="flex flex-col gap-4">
+        <div className="mag-card">
+          <div className="mag-label">Create room</div>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const fd = new FormData(e.currentTarget);
+              const form = e.currentTarget;
+              runAction(createClipboardAction, fd, () => form.reset());
+            }}
+            className="flex flex-col gap-2"
+          >
+            <input
+              type="text"
+              name="name"
+              required
+              placeholder="Room name"
+              style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+              className="px-3 py-2 rounded-sm border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 focus:outline-none focus:border-[#C4894F] dark:focus:border-[#D9A870]"
+            />
+            <button
+              type="submit"
+              disabled={pending}
+              style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 13 }}
+              className="self-end px-3 py-1.5 rounded-sm border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 hover:border-[#C4894F] dark:hover:border-[#D9A870] disabled:opacity-50 transition-colors"
+            >
+              Create
+            </button>
+          </form>
+        </div>
+
+        <div className="mag-card" style={{ padding: 0 }}>
+          <div className="px-4 py-3 border-b border-zinc-100 dark:border-zinc-800/60">
+            <div className="mag-label" style={{ marginBottom: 0 }}>
+              Rooms · {clipboards.length}
+            </div>
+          </div>
+          {clipboards.length === 0 ? (
+            <p
+              style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+              className="text-zinc-400 dark:text-zinc-600 px-4 py-3"
+            >
+              None yet — create one above.
+            </p>
+          ) : (
+            <ul>
+              {clipboards.map((c) => {
+                const isSelected = c.id === (selected?.id ?? null);
+                return (
+                  <li key={c.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedId(c.id)}
+                      className={`w-full text-left px-4 py-3 border-b border-zinc-100 dark:border-zinc-800/60 transition-colors ${
+                        isSelected
+                          ? "bg-zinc-50 dark:bg-zinc-800/60"
+                          : "hover:bg-zinc-50/60 dark:hover:bg-zinc-800/40"
+                      }`}
+                    >
+                      <div
+                        style={{ fontFamily: "'Bitter'", fontWeight: 600, fontSize: 16 }}
+                        className="text-zinc-800 dark:text-zinc-200"
+                      >
+                        {c.name}
+                      </div>
+                      <div
+                        style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                        className="text-zinc-400 dark:text-zinc-600 mt-0.5"
+                      >
+                        {c.members.length} member{c.members.length === 1 ? "" : "s"} · {c.entry_count} entr
+                        {c.entry_count === 1 ? "y" : "ies"}
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="mag-card">
+          <div className="mag-label">All users · {users.length}</div>
+          <ul className="space-y-2">
+            {users.map((u) => (
+              <li
+                key={u.id}
+                style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+                className="text-zinc-600 dark:text-zinc-400 break-all"
+              >
+                {u.email ?? "(no email)"}
+                {u.name ? (
+                  <span
+                    style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                    className="text-zinc-400 dark:text-zinc-600 ml-1"
+                  >
+                    · {u.name}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </aside>
+
+      {/* Right — selected room detail */}
+      <section className="flex flex-col gap-4">
+        {feedback ? (
+          <div
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+            className={
+              feedback.kind === "ok"
+                ? "text-green-600 dark:text-green-400"
+                : "text-red-500 dark:text-red-400"
+            }
+          >
+            {feedback.msg}
+          </div>
+        ) : null}
+
+        {!selected ? (
+          <div className="mag-card">
+            <p
+              style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+              className="text-zinc-500 dark:text-zinc-500"
+            >
+              Pick a room from the left, or create one.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="mag-card">
+              <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div>
+                  <div className="mag-label" style={{ marginBottom: 0 }}>
+                    Room
+                  </div>
+                  <h2
+                    style={{ fontFamily: "'Bitter'", fontWeight: 600, fontSize: 22 }}
+                    className="text-zinc-800 dark:text-zinc-200 mt-1"
+                  >
+                    {selected.name}
+                  </h2>
+                  <p
+                    style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                    className="text-zinc-400 dark:text-zinc-600 mt-1"
+                  >
+                    Created {new Date(selected.created_at).toLocaleString()} · {selected.entry_count} entr
+                    {selected.entry_count === 1 ? "y" : "ies"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Link
+                    href={`/clip/board/${selected.id}`}
+                    style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12 }}
+                    className="text-[#C4894F] dark:text-[#D9A870] underline underline-offset-2"
+                  >
+                    Open room →
+                  </Link>
+                  <form
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      if (!confirm(`Delete "${selected.name}" and all its history?`)) return;
+                      const fd = new FormData(e.currentTarget);
+                      runAction(deleteClipboardAction, fd);
+                    }}
+                  >
+                    <input type="hidden" name="clipboard_id" value={selected.id} />
+                    <button
+                      type="submit"
+                      disabled={pending}
+                      style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12 }}
+                      className="text-zinc-400 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                    >
+                      Delete
+                    </button>
+                  </form>
+                </div>
+              </div>
+            </div>
+
+            <div className="mag-card">
+              <div className="mag-label">Add member</div>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  const fd = new FormData(e.currentTarget);
+                  const form = e.currentTarget;
+                  runAction(addMemberAction, fd, () => form.reset());
+                }}
+                className="flex flex-col md:flex-row gap-2"
+              >
+                <input type="hidden" name="clipboard_id" value={selected.id} />
+                <select
+                  name="user_id"
+                  required
+                  defaultValue=""
+                  style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+                  className="flex-1 px-3 py-2 rounded-sm border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 focus:outline-none focus:border-[#C4894F] dark:focus:border-[#D9A870]"
+                >
+                  <option value="" disabled>
+                    Select a user
+                  </option>
+                  {nonMembers.map((u) => (
+                    <option key={u.id} value={u.id}>
+                      {u.email ?? u.id}
+                      {u.name ? ` (${u.name})` : ""}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  name="role"
+                  defaultValue="read"
+                  style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+                  className="px-3 py-2 rounded-sm border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 focus:outline-none focus:border-[#C4894F] dark:focus:border-[#D9A870]"
+                >
+                  <option value="read">read</option>
+                  <option value="write">write</option>
+                </select>
+                <button
+                  type="submit"
+                  disabled={pending || nonMembers.length === 0}
+                  style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 13 }}
+                  className="px-3 py-1.5 rounded-sm border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 hover:border-[#C4894F] dark:hover:border-[#D9A870] disabled:opacity-50 transition-colors"
+                >
+                  Add
+                </button>
+              </form>
+              {nonMembers.length === 0 ? (
+                <p
+                  style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                  className="text-zinc-400 dark:text-zinc-600 mt-2"
+                >
+                  Every signed-up user is already in this room.
+                </p>
+              ) : null}
+            </div>
+
+            <div className="mag-card" style={{ padding: 0 }}>
+              <div className="px-4 py-3 border-b border-zinc-100 dark:border-zinc-800/60">
+                <div className="mag-label" style={{ marginBottom: 0 }}>
+                  Members · {selected.members.length}
+                </div>
+              </div>
+              {selected.members.length === 0 ? (
+                <p
+                  style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+                  className="text-zinc-400 dark:text-zinc-600 px-4 py-3"
+                >
+                  No members yet.
+                </p>
+              ) : (
+                <ul>
+                  {selected.members.map((member) => {
+                    const u = usersById.get(member.user_id);
+                    return (
+                      <li
+                        key={member.user_id}
+                        className="px-4 py-3 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0 flex items-center justify-between gap-3 flex-wrap"
+                      >
+                        <div className="min-w-0">
+                          <div
+                            style={{ fontFamily: "'Bitter'", fontWeight: 600, fontSize: 14 }}
+                            className="text-zinc-800 dark:text-zinc-200 break-all"
+                          >
+                            {u?.email ?? member.user_id}
+                          </div>
+                          <div
+                            style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                            className="text-zinc-400 dark:text-zinc-600 mt-0.5"
+                          >
+                            {u?.name ? `${u.name} · ` : ""}
+                            added {new Date(member.created_at).toLocaleDateString()}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <form
+                            onSubmit={(e) => {
+                              e.preventDefault();
+                              const fd = new FormData(e.currentTarget);
+                              runAction(addMemberAction, fd);
+                            }}
+                          >
+                            <input type="hidden" name="clipboard_id" value={selected.id} />
+                            <input type="hidden" name="user_id" value={member.user_id} />
+                            <select
+                              name="role"
+                              defaultValue={member.role}
+                              onChange={(e) => e.currentTarget.form?.requestSubmit()}
+                              disabled={pending}
+                              style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12 }}
+                              className="px-2 py-1 rounded-sm border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300"
+                            >
+                              <option value="read">read</option>
+                              <option value="write">write</option>
+                            </select>
+                          </form>
+                          <form
+                            onSubmit={(e) => {
+                              e.preventDefault();
+                              if (!confirm("Remove this member?")) return;
+                              const fd = new FormData(e.currentTarget);
+                              runAction(removeMemberAction, fd);
+                            }}
+                          >
+                            <input type="hidden" name="clipboard_id" value={selected.id} />
+                            <input type="hidden" name="user_id" value={member.user_id} />
+                            <button
+                              type="submit"
+                              disabled={pending}
+                              style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12 }}
+                              className="text-zinc-400 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                            >
+                              Remove
+                            </button>
+                          </form>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/clip/admin/page.tsx
+++ b/app/clip/admin/page.tsx
@@ -1,0 +1,149 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { getServerSupabase } from "@/lib/supabase/server";
+import { getAdminSupabase } from "@/lib/supabase/admin";
+import { isAdminEmail } from "@/lib/clip/admin";
+import AdminPanel, { type AdminClipboard, type AdminUser } from "./admin-panel";
+import SignOutButton from "../sign-out-button";
+
+export const metadata: Metadata = {
+  title: "Clipboard admin · Kai Chen",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function ClipAdminPage() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/clip?next=/clip/admin");
+  if (!isAdminEmail(user.email)) {
+    return (
+      <div className="max-w-[1180px] mx-auto px-4 md:px-12 py-16">
+        <div className="mag-card max-w-md">
+          <div className="mag-label">Forbidden</div>
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14, lineHeight: 1.8 }}
+            className="text-zinc-600 dark:text-zinc-400"
+          >
+            Signed in as <span className="font-mono">{user.email}</span>, which isn&apos;t on the admin list.
+          </p>
+          <Link
+            href="/clip"
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+            className="text-[#C4894F] dark:text-[#D9A870] underline underline-offset-2 mt-4 inline-block"
+          >
+            ← Back to Clipboard Sync
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const admin = getAdminSupabase();
+
+  // Fetch users (auth.admin is privileged; service-role required).
+  const usersResult = await admin.auth.admin.listUsers({ page: 1, perPage: 200 });
+  const users: AdminUser[] = (usersResult.data?.users ?? []).map((u) => ({
+    id: u.id,
+    email: u.email ?? null,
+    name:
+      (u.user_metadata?.full_name as string | undefined) ??
+      (u.user_metadata?.name as string | undefined) ??
+      null,
+    avatar_url: (u.user_metadata?.avatar_url as string | undefined) ?? null,
+    created_at: u.created_at,
+  }));
+
+  const { data: clipboardRows } = await admin
+    .from("clipboards")
+    .select("id, name, created_at, created_by")
+    .order("created_at", { ascending: false });
+
+  const { data: memberRows } = await admin
+    .from("clipboard_members")
+    .select("clipboard_id, user_id, role, created_at");
+
+  const { data: countRows } = await admin
+    .from("clipboard_entries")
+    .select("clipboard_id");
+
+  const entryCounts = new Map<string, number>();
+  for (const row of countRows ?? []) {
+    const id = (row as { clipboard_id: string }).clipboard_id;
+    entryCounts.set(id, (entryCounts.get(id) ?? 0) + 1);
+  }
+
+  const membersByClipboard = new Map<
+    string,
+    { user_id: string; role: "read" | "write"; created_at: string }[]
+  >();
+  for (const m of memberRows ?? []) {
+    const row = m as {
+      clipboard_id: string;
+      user_id: string;
+      role: "read" | "write";
+      created_at: string;
+    };
+    const arr = membersByClipboard.get(row.clipboard_id) ?? [];
+    arr.push({ user_id: row.user_id, role: row.role, created_at: row.created_at });
+    membersByClipboard.set(row.clipboard_id, arr);
+  }
+
+  const clipboards: AdminClipboard[] = (clipboardRows ?? []).map((c) => {
+    const row = c as {
+      id: string;
+      name: string;
+      created_at: string;
+      created_by: string | null;
+    };
+    return {
+      id: row.id,
+      name: row.name,
+      created_at: row.created_at,
+      created_by: row.created_by,
+      members: membersByClipboard.get(row.id) ?? [],
+      entry_count: entryCounts.get(row.id) ?? 0,
+    };
+  });
+
+  return (
+    <div className="max-w-[1180px] mx-auto px-4 md:px-12 py-12 space-y-6">
+      <div className="fade-up flex items-end justify-between gap-4 flex-wrap" style={{ animationDelay: "0ms" }}>
+        <div>
+          <Link
+            href="/clip"
+            style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12, letterSpacing: "0.04em" }}
+            className="text-zinc-400 dark:text-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+          >
+            ← Clipboard Sync
+          </Link>
+          <h1
+            style={{ fontFamily: "'Nunito'", fontWeight: 300, letterSpacing: "-0.02em", lineHeight: 1.1 }}
+            className="text-zinc-900 dark:text-zinc-100 text-[28px] md:text-[36px] mt-1"
+          >
+            Admin
+          </h1>
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+            className="text-zinc-500 dark:text-zinc-500 mt-1"
+          >
+            Manage rooms and members. {users.length} signed-up user{users.length === 1 ? "" : "s"}.
+          </p>
+        </div>
+        <div
+          className="flex items-center gap-3"
+          style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+        >
+          <span className="text-zinc-500 dark:text-zinc-500">{user.email}</span>
+          <SignOutButton />
+        </div>
+      </div>
+
+      <AdminPanel users={users} clipboards={clipboards} />
+    </div>
+  );
+}

--- a/app/clip/board/[id]/board-realtime.tsx
+++ b/app/clip/board/[id]/board-realtime.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+import { getBrowserSupabase } from "@/lib/supabase/client";
+import type { ClipboardEntry } from "@/lib/clip/types";
+
+interface BoardRealtimeProps {
+  clipboardId: string;
+  initialEntries: ClipboardEntry[];
+  canWrite: boolean;
+  userId: string;
+}
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  const diff = Date.now() - then;
+  const sec = Math.round(diff / 1000);
+  if (sec < 30) return "just now";
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export default function BoardRealtime({
+  clipboardId,
+  initialEntries,
+  canWrite,
+  userId,
+}: BoardRealtimeProps) {
+  const supabase = useMemo(() => getBrowserSupabase(), []);
+  const [entries, setEntries] = useState<ClipboardEntry[]>(initialEntries);
+  const [selectedId, setSelectedId] = useState<string | null>(initialEntries[0]?.id ?? null);
+  const [draft, setDraft] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [, setTick] = useState(0);
+
+  const channelRef = useRef<RealtimeChannel | null>(null);
+
+  // Refresh "x ago" labels every 30s without re-fetching.
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`clipboard:${clipboardId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "clipboard_entries",
+          filter: `clipboard_id=eq.${clipboardId}`,
+        },
+        (payload) => {
+          const row = payload.new as ClipboardEntry;
+          setEntries((prev) => {
+            if (prev.some((e) => e.id === row.id)) return prev;
+            return [row, ...prev];
+          });
+          setSelectedId((cur) => cur ?? row.id);
+        }
+      )
+      .subscribe();
+
+    channelRef.current = channel;
+    return () => {
+      void supabase.removeChannel(channel);
+      channelRef.current = null;
+    };
+  }, [supabase, clipboardId]);
+
+  const selected = useMemo(
+    () => entries.find((e) => e.id === selectedId) ?? entries[0] ?? null,
+    [entries, selectedId]
+  );
+
+  const handleSubmit = useCallback(
+    async (e?: React.FormEvent) => {
+      e?.preventDefault();
+      if (!canWrite) return;
+      const content = draft;
+      if (!content.trim()) return;
+      setSubmitting(true);
+      setError(null);
+      try {
+        const { error: insertError } = await supabase
+          .from("clipboard_entries")
+          .insert({ clipboard_id: clipboardId, user_id: userId, content });
+        if (insertError) {
+          setError(insertError.message);
+        } else {
+          setDraft("");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to submit");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [canWrite, draft, supabase, clipboardId, userId]
+  );
+
+  const onCopy = useCallback(async () => {
+    if (!selected) return;
+    try {
+      await navigator.clipboard.writeText(selected.content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API may be blocked; ignore silently.
+    }
+  }, [selected]);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[280px_1fr] gap-4 fade-up" style={{ animationDelay: "60ms" }}>
+      {/* Left — history list */}
+      <aside className="mag-card md:max-h-[70vh] md:overflow-y-auto" style={{ padding: 0 }}>
+        <div className="p-4 sticky top-0 bg-inherit z-10 border-b border-zinc-100 dark:border-zinc-800/60">
+          <div className="mag-label" style={{ marginBottom: 0 }}>
+            History · {entries.length}
+          </div>
+        </div>
+        {entries.length === 0 ? (
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+            className="text-zinc-400 dark:text-zinc-600 px-4 py-3"
+          >
+            Nothing here yet.
+          </p>
+        ) : (
+          <ul>
+            {entries.map((entry) => {
+              const isSelected = entry.id === (selected?.id ?? null);
+              const preview = entry.content.replace(/\s+/g, " ").trim().slice(0, 80);
+              return (
+                <li key={entry.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedId(entry.id)}
+                    className={`w-full text-left px-4 py-3 border-b border-zinc-100 dark:border-zinc-800/60 transition-colors duration-150 ${
+                      isSelected
+                        ? "bg-zinc-50 dark:bg-zinc-800/60"
+                        : "hover:bg-zinc-50/60 dark:hover:bg-zinc-800/40"
+                    }`}
+                  >
+                    <div
+                      style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14, lineHeight: 1.5 }}
+                      className="text-zinc-700 dark:text-zinc-300 line-clamp-2"
+                    >
+                      {preview || "(empty)"}
+                    </div>
+                    <div
+                      style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                      className="text-zinc-400 dark:text-zinc-600 mt-1"
+                    >
+                      {relativeTime(entry.created_at)}
+                      {entry.user_id === userId ? " · you" : ""}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </aside>
+
+      {/* Right — current editor + selected detail */}
+      <section className="flex flex-col gap-4">
+        <div className="mag-card">
+          <div className="flex items-center justify-between">
+            <div className="mag-label" style={{ marginBottom: 0 }}>
+              {canWrite ? "New entry" : "Read-only"}
+            </div>
+            {!canWrite ? (
+              <span
+                style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11, letterSpacing: "0.05em" }}
+                className="text-zinc-400 dark:text-zinc-600 uppercase"
+              >
+                You can view but not write.
+              </span>
+            ) : null}
+          </div>
+          <form onSubmit={handleSubmit} className="mt-3 flex flex-col gap-2">
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              disabled={!canWrite || submitting}
+              rows={6}
+              placeholder={canWrite ? "Paste or type, then submit. Everyone in the room sees it instantly." : "Read-only — editing disabled"}
+              style={{ fontFamily: "var(--font-jetbrains-mono)", fontSize: 13, lineHeight: 1.6 }}
+              className="w-full resize-y px-3 py-2 rounded-sm border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 focus:outline-none focus:border-[#C4894F] dark:focus:border-[#D9A870] disabled:opacity-60"
+            />
+            <div className="flex items-center justify-between gap-2">
+              <span
+                style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                className="text-zinc-400 dark:text-zinc-600"
+              >
+                {error ?? `${draft.length} character${draft.length === 1 ? "" : "s"}`}
+              </span>
+              <button
+                type="submit"
+                disabled={!canWrite || submitting || !draft.trim()}
+                style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 13, letterSpacing: "0.02em" }}
+                className="px-4 py-1.5 rounded-sm border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 hover:border-[#C4894F] dark:hover:border-[#D9A870] disabled:opacity-50 transition-colors duration-150"
+              >
+                {submitting ? "Sending…" : "Submit"}
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div className="mag-card">
+          <div className="flex items-center justify-between">
+            <div className="mag-label" style={{ marginBottom: 0 }}>
+              {selected ? "Selected entry" : "No entry selected"}
+            </div>
+            {selected ? (
+              <button
+                type="button"
+                onClick={onCopy}
+                style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12 }}
+                className="text-zinc-500 dark:text-zinc-500 hover:text-[#C4894F] dark:hover:text-[#D9A870] transition-colors"
+              >
+                {copied ? "Copied ✓" : "Copy"}
+              </button>
+            ) : null}
+          </div>
+          {selected ? (
+            <>
+              <div
+                style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                className="text-zinc-400 dark:text-zinc-600 mt-2"
+              >
+                {new Date(selected.created_at).toLocaleString()} · {relativeTime(selected.created_at)}
+                {selected.user_id === userId ? " · you" : ""}
+              </div>
+              <pre
+                style={{ fontFamily: "var(--font-jetbrains-mono)", fontSize: 13, lineHeight: 1.7 }}
+                className="mt-3 whitespace-pre-wrap break-words text-zinc-800 dark:text-zinc-200"
+              >
+                {selected.content}
+              </pre>
+            </>
+          ) : (
+            <p
+              style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+              className="text-zinc-400 dark:text-zinc-600 mt-2"
+            >
+              Submit something or pick an entry from the history.
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/clip/board/[id]/page.tsx
+++ b/app/clip/board/[id]/page.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { getServerSupabase } from "@/lib/supabase/server";
+import type { ClipboardEntry, ClipboardRole } from "@/lib/clip/types";
+import BoardRealtime from "./board-realtime";
+import SignOutButton from "../../sign-out-button";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const supabase = await getServerSupabase();
+  const { data } = await supabase.from("clipboards").select("name").eq("id", id).maybeSingle();
+  return {
+    title: data?.name ? `${data.name} · Clipboard Sync` : "Clipboard Sync",
+  };
+}
+
+export default async function BoardPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await getServerSupabase();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect(`/clip?next=${encodeURIComponent(`/clip/board/${id}`)}`);
+
+  // Pull current user's role; RLS already restricts to rooms they belong to.
+  const { data: membership } = await supabase
+    .from("clipboard_members")
+    .select("role")
+    .eq("clipboard_id", id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    return (
+      <div className="max-w-[1180px] mx-auto px-4 md:px-12 py-16">
+        <div className="mag-card max-w-md">
+          <div className="mag-label">No access</div>
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14, lineHeight: 1.8 }}
+            className="text-zinc-600 dark:text-zinc-400"
+          >
+            You don&apos;t have permission to view this clipboard. Ask the admin to add you.
+          </p>
+          <Link
+            href="/clip"
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+            className="text-[#C4894F] dark:text-[#D9A870] underline underline-offset-2 mt-4 inline-block"
+          >
+            ← Back to rooms
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const role = membership.role as ClipboardRole;
+
+  const { data: clipboard } = await supabase
+    .from("clipboards")
+    .select("id, name, created_at")
+    .eq("id", id)
+    .maybeSingle();
+  if (!clipboard) notFound();
+
+  const { data: entryRows } = await supabase
+    .from("clipboard_entries")
+    .select("id, clipboard_id, user_id, content, created_at")
+    .eq("clipboard_id", id)
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  const initialEntries = (entryRows ?? []) as ClipboardEntry[];
+
+  return (
+    <div className="max-w-[1180px] mx-auto px-4 md:px-12 py-12 space-y-6">
+      <div className="fade-up flex items-end justify-between gap-4 flex-wrap" style={{ animationDelay: "0ms" }}>
+        <div>
+          <Link
+            href="/clip"
+            style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12, letterSpacing: "0.04em" }}
+            className="text-zinc-400 dark:text-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+          >
+            ← All rooms
+          </Link>
+          <h1
+            style={{ fontFamily: "'Nunito'", fontWeight: 300, letterSpacing: "-0.02em", lineHeight: 1.1 }}
+            className="text-zinc-900 dark:text-zinc-100 text-[28px] md:text-[36px] mt-1"
+          >
+            {clipboard.name}
+          </h1>
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+            className="text-zinc-400 dark:text-zinc-600 mt-1"
+          >
+            Created {new Date(clipboard.created_at).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+            {" · "}
+            <span className="uppercase tracking-wider">{role}</span>
+          </p>
+        </div>
+        <div
+          className="flex items-center gap-3"
+          style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+        >
+          <span className="text-zinc-500 dark:text-zinc-500">{user.email}</span>
+          <SignOutButton />
+        </div>
+      </div>
+
+      <BoardRealtime
+        clipboardId={clipboard.id}
+        initialEntries={initialEntries}
+        canWrite={role === "write"}
+        userId={user.id}
+      />
+    </div>
+  );
+}

--- a/app/clip/page.tsx
+++ b/app/clip/page.tsx
@@ -1,0 +1,176 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { getServerSupabase } from "@/lib/supabase/server";
+import { isAdminEmail } from "@/lib/clip/admin";
+import type { ClipboardWithRole } from "@/lib/clip/types";
+import SignInButton from "./sign-in-button";
+import SignOutButton from "./sign-out-button";
+
+export const metadata: Metadata = {
+  title: "Clipboard Sync · Kai Chen",
+  description: "Shared clipboard rooms, synced in real time.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function ClipHome() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <div className="max-w-[1180px] mx-auto px-4 md:px-12 py-16 space-y-8">
+      <div className="fade-up flex items-end justify-between gap-4 flex-wrap" style={{ animationDelay: "0ms" }}>
+        <div>
+          <h1
+            style={{ fontFamily: "'Nunito'", fontWeight: 300, letterSpacing: "-0.02em", lineHeight: 1.1 }}
+            className="text-zinc-900 dark:text-zinc-100 text-[36px] md:text-[48px]"
+          >
+            Clipboard Sync
+          </h1>
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 15, lineHeight: 1.9 }}
+            className="text-zinc-500 dark:text-zinc-500 mt-2"
+          >
+            A small place to ferry text between machines. Sign in with Google to see the rooms you can read or write.
+          </p>
+        </div>
+        {user ? (
+          <div
+            className="flex items-center gap-3"
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+          >
+            <span className="text-zinc-500 dark:text-zinc-500">{user.email}</span>
+            <SignOutButton />
+          </div>
+        ) : null}
+      </div>
+
+      {!user ? (
+        <div className="mag-card fade-up max-w-md" style={{ animationDelay: "60ms" }}>
+          <div className="mag-label">Sign in</div>
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14, lineHeight: 1.8 }}
+            className="text-zinc-600 dark:text-zinc-400 mb-4"
+          >
+            Access is invite-only. After signing in, ask the admin to add you to a room.
+          </p>
+          <SignInButton next="/clip" />
+        </div>
+      ) : (
+        <SignedInView userId={user.id} userEmail={user.email ?? null} />
+      )}
+    </div>
+  );
+}
+
+async function SignedInView({ userId, userEmail }: { userId: string; userEmail: string | null }) {
+  const supabase = await getServerSupabase();
+
+  // RLS limits the visible rows to clipboards the user is a member of.
+  const { data: memberships, error } = await supabase
+    .from("clipboard_members")
+    .select("role, clipboards(id, name, created_by, created_at)")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return (
+      <div className="mag-card max-w-md fade-up" style={{ animationDelay: "60ms" }}>
+        <div className="mag-label">Error</div>
+        <p
+          style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+          className="text-red-500 dark:text-red-400"
+        >
+          Couldn&apos;t load your rooms: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  type MembershipRow = {
+    role: "read" | "write";
+    clipboards: {
+      id: string;
+      name: string;
+      created_by: string | null;
+      created_at: string;
+    } | null;
+  };
+
+  const rooms: ClipboardWithRole[] = (memberships ?? [])
+    .map((m) => {
+      const row = m as unknown as MembershipRow;
+      if (!row.clipboards) return null;
+      return { ...row.clipboards, role: row.role };
+    })
+    .filter((r): r is ClipboardWithRole => r !== null)
+    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+
+  const isAdmin = isAdminEmail(userEmail);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 fade-up" style={{ animationDelay: "60ms" }}>
+      <div className="mag-card md:col-span-2">
+        <div className="mag-label">Your rooms</div>
+        {rooms.length === 0 ? (
+          <p
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14, lineHeight: 1.8 }}
+            className="text-zinc-400 dark:text-zinc-600 py-2"
+          >
+            No rooms yet. Once an admin adds you to a clipboard, it will appear here.
+          </p>
+        ) : (
+          <div>
+            {rooms.map((room) => (
+              <Link
+                key={room.id}
+                href={`/clip/board/${room.id}`}
+                className="group flex items-baseline justify-between gap-3 py-3 -mx-2 px-2 rounded-sm hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-all duration-150 no-underline"
+                style={{ textDecoration: "none" }}
+              >
+                <span className="flex items-baseline gap-2 min-w-0 flex-1">
+                  <span className="opacity-0 group-hover:opacity-100 text-[#C4894F] -translate-x-1 group-hover:translate-x-0 transition-all duration-150 text-xs shrink-0">
+                    ↗
+                  </span>
+                  <span
+                    style={{ fontFamily: "'Bitter'", fontWeight: 600, fontSize: 18, fontStyle: "italic" }}
+                    className="text-zinc-800 dark:text-zinc-200 group-hover:text-[#C4894F] dark:group-hover:text-[#D9A870] transition-colors duration-150 line-clamp-1"
+                  >
+                    {room.name}
+                  </span>
+                  <span
+                    style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 10, letterSpacing: "0.05em" }}
+                    className="px-1.5 py-0.5 rounded-sm bg-zinc-100 dark:bg-zinc-800/80 text-zinc-500 dark:text-zinc-400 uppercase shrink-0"
+                  >
+                    {room.role}
+                  </span>
+                </span>
+                <span
+                  style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 11 }}
+                  className="text-zinc-400 dark:text-zinc-600 shrink-0"
+                >
+                  {new Date(room.created_at).toLocaleDateString("en-US", { month: "short", year: "numeric" })}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {isAdmin ? (
+        <div className="mag-card md:col-span-2">
+          <div className="mag-label">Admin</div>
+          <Link
+            href="/clip/admin"
+            style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 14 }}
+            className="text-[#C4894F] dark:text-[#D9A870] underline underline-offset-2 hover:opacity-80 transition-opacity"
+          >
+            Open admin panel →
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/clip/sign-in-button.tsx
+++ b/app/clip/sign-in-button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { getBrowserSupabase } from "@/lib/supabase/client";
+
+export default function SignInButton({ next }: { next?: string }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSignIn() {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = getBrowserSupabase();
+      const callback = new URL("/auth/callback", window.location.origin);
+      if (next) callback.searchParams.set("next", next);
+      const { error: oauthError } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: { redirectTo: callback.toString() },
+      });
+      if (oauthError) setError(oauthError.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Sign-in failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <button
+        type="button"
+        onClick={handleSignIn}
+        disabled={loading}
+        style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 14, letterSpacing: "0.02em" }}
+        className="px-4 py-2 rounded-sm border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 hover:border-[#C4894F] dark:hover:border-[#D9A870] disabled:opacity-50 transition-colors duration-150 inline-flex items-center gap-2"
+      >
+        <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
+          <path fill="#FFC107" d="M43.6 20.5H42V20H24v8h11.3c-1.6 4.6-6 8-11.3 8-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3.1l5.7-5.7C34 6.1 29.3 4 24 4 12.9 4 4 12.9 4 24s8.9 20 20 20 20-8.9 20-20c0-1.3-.1-2.3-.4-3.5z" />
+          <path fill="#FF3D00" d="m6.3 14.7 6.6 4.8c1.8-4.4 6.1-7.5 11.1-7.5 3.1 0 5.9 1.2 8 3.1l5.7-5.7C34 6.1 29.3 4 24 4 16.3 4 9.7 8.3 6.3 14.7z" />
+          <path fill="#4CAF50" d="M24 44c5.2 0 10-2 13.6-5.2l-6.3-5.2c-2 1.4-4.5 2.4-7.3 2.4-5.3 0-9.7-3.4-11.3-8l-6.5 5C9.6 39.6 16.2 44 24 44z" />
+          <path fill="#1976D2" d="M43.6 20.5H42V20H24v8h11.3c-.8 2.2-2.2 4.1-4 5.5l6.3 5.2C41.9 35.7 44 30.3 44 24c0-1.3-.1-2.3-.4-3.5z" />
+        </svg>
+        {loading ? "Signing in…" : "Continue with Google"}
+      </button>
+      {error ? (
+        <p
+          style={{ fontFamily: "'Bitter'", fontWeight: 400, fontSize: 13 }}
+          className="text-red-500 dark:text-red-400"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/app/clip/sign-out-button.tsx
+++ b/app/clip/sign-out-button.tsx
@@ -1,0 +1,13 @@
+export default function SignOutButton() {
+  return (
+    <form action="/auth/sign-out" method="post">
+      <button
+        type="submit"
+        style={{ fontFamily: "'Nunito'", fontWeight: 400, fontSize: 12, letterSpacing: "0.02em" }}
+        className="text-zinc-400 dark:text-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors duration-150 underline underline-offset-2 decoration-zinc-200 dark:decoration-zinc-800"
+      >
+        Sign out
+      </button>
+    </form>
+  );
+}

--- a/lib/clip/admin.ts
+++ b/lib/clip/admin.ts
@@ -1,0 +1,15 @@
+/**
+ * Comma-separated list of admin emails read from `ADMIN_EMAILS`.
+ * Server-only — do not import from client components.
+ */
+export function getAdminEmails(): string[] {
+  return (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAdminEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  return getAdminEmails().includes(email.trim().toLowerCase());
+}

--- a/lib/clip/types.ts
+++ b/lib/clip/types.ts
@@ -1,0 +1,28 @@
+export type ClipboardRole = "read" | "write";
+
+export interface Clipboard {
+  id: string;
+  name: string;
+  created_by: string | null;
+  created_at: string;
+}
+
+export interface ClipboardMember {
+  id: string;
+  clipboard_id: string;
+  user_id: string;
+  role: ClipboardRole;
+  created_at: string;
+}
+
+export interface ClipboardEntry {
+  id: string;
+  clipboard_id: string;
+  user_id: string | null;
+  content: string;
+  created_at: string;
+}
+
+export interface ClipboardWithRole extends Clipboard {
+  role: ClipboardRole;
+}

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let adminClient: SupabaseClient | undefined;
+
+/**
+ * Service-role client. Bypasses RLS — use ONLY in trusted server contexts
+ * (API routes, server actions) after verifying the caller's identity.
+ */
+export function getAdminSupabase(): SupabaseClient {
+  if (!adminClient) {
+    adminClient = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      }
+    );
+  }
+  return adminClient;
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+let browserClient: SupabaseClient | undefined;
+
+export function getBrowserSupabase(): SupabaseClient {
+  if (!browserClient) {
+    browserClient = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+  }
+  return browserClient;
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function getServerSupabase(): Promise<SupabaseClient> {
+  const cookieStore = await cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          // Server Components cannot mutate cookies. Middleware refreshes the
+          // session cookie on every request, so silently swallow write errors.
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options);
+            });
+          } catch {
+            // No-op: read-only context.
+          }
+        },
+      },
+    }
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.2.4",
         "@sentry/nextjs": "^10.49.0",
+        "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
@@ -3373,6 +3374,18 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
+      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.102.1"
+      }
+    },
     "node_modules/@supabase/storage-js": {
       "version": "2.104.0",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.0.tgz",
@@ -5693,6 +5706,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^16.2.4",
     "@sentry/nextjs": "^10.49.0",
+    "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+const CLIP_HOST = "clip.kaichen.dev";
+
+export async function proxy(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+  const host = request.headers.get("host") ?? "";
+
+  // ── Subdomain rewrite ──────────────────────────────────────────────────
+  // clip.kaichen.dev → /clip path, so a single Next.js project can serve both
+  // kaichen.dev/clip and clip.kaichen.dev seamlessly.
+  if (host === CLIP_HOST && !pathname.startsWith("/clip") && !pathname.startsWith("/auth") && !pathname.startsWith("/api") && !pathname.startsWith("/_next")) {
+    const url = request.nextUrl.clone();
+    url.pathname = pathname === "/" ? "/clip" : `/clip${pathname}`;
+    url.search = search;
+    return NextResponse.rewrite(url);
+  }
+
+  // ── Supabase session refresh ──────────────────────────────────────────
+  // Required for cookie-based auth across server components / actions.
+  // (Next 16 calls this layer "proxy"; the API mirrors the legacy middleware.)
+  let response = NextResponse.next({ request });
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return response;
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+        response = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) =>
+          response.cookies.set(name, value, options)
+        );
+      },
+    },
+  });
+
+  await supabase.auth.getUser();
+  return response;
+}
+
+export const config = {
+  matcher: [
+    // Skip static + image + favicon assets to keep this layer lean.
+    "/((?!_next/static|_next/image|favicon.ico|opengraph-image|apple-icon|icon|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

- Adds **Clipboard Sync** at `/clip` (and `clip.kaichen.dev` via subdomain rewrite): Google sign-in (Supabase Auth + cookie session via `@supabase/ssr`), per-room access controlled through Supabase RLS, and live updates via Supabase Realtime `postgres_changes` on `clipboard_entries`.
- Adds `/clip/admin` (gated by `ADMIN_EMAILS`): list signed-up users, create/delete rooms, manage `read` / `write` membership through service-role server actions.
- Adds Next.js 16 `proxy.ts` (the new name for `middleware.ts`) that refreshes the Supabase auth cookie on every request and rewrites `clip.kaichen.dev/*` → `/clip/*` so a single Vercel project serves both hosts.
- Documents the feature, new env vars (`NEXT_PUBLIC_SUPABASE_ANON_KEY`, `ADMIN_EMAILS`), redirect URLs, and Vercel domain setup in `README.md` + `.env.example`.

## Files of note

- `app/clip/page.tsx` — sign-in landing + room list (RLS-scoped query)
- `app/clip/board/[id]/page.tsx` + `board-realtime.tsx` — server data + client realtime UI
- `app/clip/admin/{page,admin-panel,admin-actions}.tsx` — admin-only management
- `app/auth/{callback,sign-out}/route.ts` — Supabase OAuth flow
- `lib/supabase/{client,server,admin}.ts` — three explicit Supabase client variants
- `lib/clip/{admin,types}.ts` — admin-email helper + shared types
- `proxy.ts` — session refresh + subdomain rewrite

## Required env vars (already present in production except the new ones)

- `NEXT_PUBLIC_SUPABASE_URL` (existing)
- `NEXT_PUBLIC_SUPABASE_ANON_KEY` (**new** — public anon key for cookie auth)
- `SUPABASE_SERVICE_ROLE_KEY` (existing)
- `ADMIN_EMAILS` (**new** — comma-separated, e.g. `kaichen26@berkeley.edu`)

## Supabase setup (outside this PR)

- Schema (`clipboards`, `clipboard_members`, `clipboard_entries`) already created.
- Add redirect URLs `https://kaichen.dev/auth/callback`, `https://clip.kaichen.dev/auth/callback`, and `http://localhost:3000/auth/callback`. Enable the Google provider.
- Enable **Realtime** on `clipboard_entries` and ensure RLS policies expose only rows the user is a member of (the browser relies on RLS for `SELECT`/`INSERT`).

## Vercel setup

- Add `clip.kaichen.dev` as a domain on this project. The `proxy.ts` rewrite handles routing — no separate project needed.
- Set the new env vars in Production + Preview.

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test && npm run build` all clean (no new warnings introduced).
- [ ] In a deploy preview with env vars set: visit `/clip`, sign in with Google, get redirected back, see room list (likely empty for a non-admin).
- [ ] As an `ADMIN_EMAILS` user, open `/clip/admin`, create a room, add yourself with `write`, open the room, post an entry, and verify it appears in another browser/incognito session for a different member in real time.
- [ ] Confirm a non-admin cannot reach `/clip/admin` (403-style fallback).
- [ ] Hit `https://clip.kaichen.dev/` after deploy and confirm it serves the `/clip` page (rewrite works) and the `/auth/callback` redirect URL works against that host.

Made with [Cursor](https://cursor.com)